### PR TITLE
fix: use empty favicon as default

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,11 @@
     <title>OneCX Portal</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      href="data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQEAYAAABPYyMiAAAABmJLR0T///////8JWPfcAAAACXBIWXMAAABIAAAASABGyWs+AAAAF0lEQVRIx2NgGAWjYBSMglEwCkbBSAcACBAAAeaR9cIAAAAASUVORK5CYII="
+      rel="icon"
+      type="image/x-icon"
+    />
   </head>
   <body>
     <ocx-shell-root></ocx-shell-root>


### PR DESCRIPTION
This PR adds an empty favicon to be the default value for the shell:
![image](https://github.com/user-attachments/assets/e3eb53cb-8d6c-4967-bcf5-e457d1b5081e)